### PR TITLE
Hostname setting

### DIFF
--- a/Release.toml
+++ b/Release.toml
@@ -58,3 +58,8 @@ version = "1.1.3"
     "migrate_v1.1.3_kubelet-cpu-manager-state.lz4",
     "migrate_v1.1.3_kubelet-cpu-manager.lz4",
 ]
+"(1.1.3, 1.1.4)" = []
+"(1.1.4, 1.1.5)" = [
+    "migrate_v1.1.5_hostname-setting.lz4",
+    "migrate_v1.1.5_hostname-setting-metadata.lz4",
+]

--- a/packages/os/os.spec
+++ b/packages/os/os.spec
@@ -37,6 +37,7 @@ Source111: metricdog.service
 Source112: metricdog.timer
 Source113: send-boot-success.service
 Source114: bootstrap-containers@.service
+Source115: set-hostname.service
 
 # 2xx sources: tmpfilesd configs
 Source200: migration-tmpfiles.conf
@@ -394,7 +395,7 @@ install -d %{buildroot}%{_cross_unitdir}
 install -p -m 0644 \
   %{S:100} %{S:101} %{S:102} %{S:103} %{S:105} \
   %{S:106} %{S:107} %{S:110} %{S:111} %{S:112} \
-  %{S:113} %{S:114} \
+  %{S:113} %{S:114} %{S:115} \
   %{buildroot}%{_cross_unitdir}
 
 install -d %{buildroot}%{_cross_tmpfilesdir}
@@ -531,5 +532,7 @@ install -p -m 0644 %{S:300} %{buildroot}%{_cross_udevrulesdir}/80-ephemeral-stor
 %{_cross_bindir}/bootstrap-containers
 %{_cross_unitdir}/bootstrap-containers@.service
 %{_cross_tmpfilesdir}/bootstrap-containers.conf
+
+%{_cross_unitdir}/set-hostname.service
 
 %changelog

--- a/packages/os/set-hostname.service
+++ b/packages/os/set-hostname.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Sets the hostname
+After=settings-applier.service
+Requires=settings-applier.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/network/hostname.env
+ExecStart=/usr/bin/netdog set-hostname --hostname '${HOSTNAME}'
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/release/hostname.template
+++ b/packages/release/hostname.template
@@ -1,0 +1,1 @@
+HOSTNAME={{settings.network.hostname}}

--- a/packages/release/release.spec
+++ b/packages/release/release.spec
@@ -14,6 +14,7 @@ Source99: release-tmpfiles.conf
 
 Source200: motd.template
 Source201: proxy-env
+Source202: hostname.template
 
 Source1000: eth0.xml
 Source1001: multi-user.target
@@ -129,6 +130,7 @@ install -p -m 0644 ${LICENSEPATH}.mount %{buildroot}%{_cross_unitdir}
 install -d %{buildroot}%{_cross_templatedir}
 install -p -m 0644 %{S:200} %{buildroot}%{_cross_templatedir}/motd
 install -p -m 0644 %{S:201} %{buildroot}%{_cross_templatedir}/proxy-env
+install -p -m 0644 %{S:202} %{buildroot}%{_cross_templatedir}/hostname
 
 install -d %{buildroot}%{_cross_udevrulesdir}
 install -p -m 0644 %{S:1016} %{buildroot}%{_cross_udevrulesdir}/61-mount-cdrom.rules
@@ -166,6 +168,7 @@ ln -s %{_cross_unitdir}/preconfigured.target %{buildroot}%{_cross_unitdir}/defau
 %dir %{_cross_templatedir}
 %{_cross_templatedir}/motd
 %{_cross_templatedir}/proxy-env
+%{_cross_templatedir}/hostname
 %{_cross_udevrulesdir}/61-mount-cdrom.rules
 
 %changelog

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1314,6 +1314,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname-setting"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
+name = "hostname-setting-metadata"
+version = "0.1.0"
+dependencies = [
+ "migration-helpers",
+]
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/sources/Cargo.lock
+++ b/sources/Cargo.lock
@@ -1853,6 +1853,7 @@ dependencies = [
 name = "netdog"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "cargo-readme",
  "dns-lookup",
  "envy",

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -37,6 +37,8 @@ members = [
     "api/migration/migrations/v1.1.2/control-container-v0-5-1",
     "api/migration/migrations/v1.1.3/kubelet-cpu-manager-state",
     "api/migration/migrations/v1.1.3/kubelet-cpu-manager",
+    "api/migration/migrations/v1.1.5/hostname-setting",
+    "api/migration/migrations/v1.1.5/hostname-setting-metadata",
 
     "bottlerocket-release",
 

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hostname-setting-metadata"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting-metadata/src/main.rs
@@ -1,0 +1,23 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::{AddMetadataMigration, SettingMetadata};
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and generator for configuring hostname
+fn run() -> Result<()> {
+    migrate(AddMetadataMigration(&[SettingMetadata {
+        metadata: &["setting-generator", "affected-services"],
+        setting: "settings.network.hostname",
+    }]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting/Cargo.toml
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "hostname-setting"
+version = "0.1.0"
+authors = ["Zac Mrowicki <mrowicki@amazon.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+publish = false
+# Don't rebuild crate just because of changes to README.
+exclude = ["README.md"]
+
+[dependencies]
+migration-helpers = { path = "../../../migration-helpers" }

--- a/sources/api/migration/migrations/v1.1.5/hostname-setting/src/main.rs
+++ b/sources/api/migration/migrations/v1.1.5/hostname-setting/src/main.rs
@@ -1,0 +1,24 @@
+#![deny(rust_2018_idioms)]
+
+use migration_helpers::common_migrations::AddPrefixesMigration;
+use migration_helpers::{migrate, Result};
+use std::process;
+
+/// We added a new setting and generator for configuring hostname
+fn run() -> Result<()> {
+    migrate(AddPrefixesMigration(vec![
+        "settings.network.hostname",
+        "services.hostname",
+        "configuration-files.hostname",
+    ]))
+}
+
+// Returning a Result from main makes it print a Debug representation of the error, but with Snafu
+// we have nice Display representations of the error, so we wrap "main" (run) and print any error.
+// https://github.com/shepmaster/snafu/issues/110
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{}", e);
+        process::exit(1);
+    }
+}

--- a/sources/api/netdog/Cargo.toml
+++ b/sources/api/netdog/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 exclude = ["README.md"]
 
 [dependencies]
+argh = "0.1.4"
 dns-lookup = "1.0"
 ipnet = { version = "2.0", features = ["serde"] }
 envy = "0.4"

--- a/sources/api/netdog/README.md
+++ b/sources/api/netdog/README.md
@@ -4,11 +4,13 @@ Current version: 0.1.0
 
 ## Introduction
 
-netdog is a small helper program for wicked, to apply network settings received from DHCP.  It also
-contains a subcommand `node-ip` that returns the node's current IP address in JSON format; this
-subcommand is intended for use as a settings generator.
+netdog is a small helper program for wicked, to apply network settings received from DHCP.  It
+generates `/etc/resolv.conf`, generates and sets the hostname, and persists the current IP to file.
 
-It generates `/etc/resolv.conf`, sets the hostname, and persists the current IP to file.
+It contains two subcommands meant for use as settings generators:
+* `node-ip`: returns the node's current IP address in JSON format
+* `generate-hostname`: returns the node's hostname in JSON format (it is the resolved IP or the IP
+  in format "ip-x-x-x-x" if resolving fails)
 
 ## Colophon
 

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -1,11 +1,13 @@
 /*!
 # Introduction
 
-netdog is a small helper program for wicked, to apply network settings received from DHCP.  It also
-contains a subcommand `node-ip` that returns the node's current IP address in JSON format; this
-subcommand is intended for use as a settings generator.
+netdog is a small helper program for wicked, to apply network settings received from DHCP.  It
+generates `/etc/resolv.conf`, generates and sets the hostname, and persists the current IP to file.
 
-It generates `/etc/resolv.conf`, sets the hostname, and persists the current IP to file.
+It contains two subcommands meant for use as settings generators:
+* `node-ip`: returns the node's current IP address in JSON format
+* `generate-hostname`: returns the node's hostname in JSON format (it is the resolved IP or the IP
+  in format "ip-x-x-x-x" if resolving fails)
 */
 
 // TODO:
@@ -28,7 +30,7 @@ use lazy_static::lazy_static;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use regex::Regex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use std::collections::BTreeSet;
 use std::fmt::Write;
@@ -37,6 +39,7 @@ use std::io::{BufRead, BufReader};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::process;
+use std::str::FromStr;
 
 static RESOLV_CONF: &str = "/etc/resolv.conf";
 static KERNEL_HOSTNAME: &str = "/proc/sys/kernel/hostname";
@@ -98,6 +101,7 @@ enum SubCommand {
     Install(InstallArgs),
     Remove(RemoveArgs),
     NodeIp(NodeIpArgs),
+    GenerateHostname(GenerateHostnameArgs),
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
@@ -160,6 +164,11 @@ struct RemoveArgs {
 #[argh(subcommand, name = "node-ip")]
 /// Return the current IP address
 struct NodeIpArgs {}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "generate-hostname")]
+/// Generate hostname from DNS reverse lookup or use current IP
+struct GenerateHostnameArgs {}
 
 /// Parse lease data file into a LeaseInfo structure.
 fn parse_lease_info<P>(lease_file: P) -> Result<LeaseInfo>
@@ -259,7 +268,37 @@ fn node_ip() -> Result<()> {
     let ip =
         fs::read_to_string(CURRENT_IP).context(error::CurrentIpReadFailed { path: CURRENT_IP })?;
     // sundog expects JSON-serialized output
-    let output = serde_json::to_string(&ip).context(error::JsonSerialize { output: ip })?;
+    Ok(print_json(ip)?)
+}
+
+/// Attempt to resolve assigned IP address, if unsuccessful use "ip-X-X-X-X" where X's are the
+/// octets of the IP.  For example, IP address 1.2.3.4 becomes the hostname "ip-1-2-3-4".  No dots
+/// in the hostname (hopefully) avoids any confusion for programs that may read this value.
+///
+/// The result is returned as JSON. (intended for use as a settings generator)
+fn generate_hostname() -> Result<()> {
+    let ip_string =
+        fs::read_to_string(CURRENT_IP).context(error::CurrentIpReadFailed { path: CURRENT_IP })?;
+    let ip = IpAddr::from_str(&ip_string).context(error::IpFromString { ip: &ip_string })?;
+    let hostname = match lookup_addr(&ip) {
+        Ok(hostname) => hostname,
+        Err(e) => {
+            eprintln!("Reverse DNS lookup failed: {}", e);
+            format!("ip-{}", ip_string.replace(".", "-"))
+        }
+    };
+
+    // sundog expects JSON-serialized output
+    Ok(print_json(hostname)?)
+}
+
+/// Helper function that serializes the input to JSON and prints it
+fn print_json<S>(val: S) -> Result<()>
+where
+    S: AsRef<str> + Serialize,
+{
+    let val = val.as_ref();
+    let output = serde_json::to_string(val).context(error::JsonSerialize { output: val })?;
     println!("{}", output);
     Ok(())
 }
@@ -270,6 +309,7 @@ fn run() -> Result<()> {
         SubCommand::Install(args) => install(args)?,
         SubCommand::Remove(args) => remove(args)?,
         SubCommand::NodeIp(_) => node_ip()?,
+        SubCommand::GenerateHostname(_) => generate_hostname()?,
     }
     Ok(())
 }
@@ -313,6 +353,12 @@ mod error {
 
         #[snafu(display("Failed to write hostname to '{}': {}", path.display(), source))]
         HostnameWriteFailed { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Invalid IP address '{}': {}", ip, source))]
+        IpFromString {
+            ip: String,
+            source: std::net::AddrParseError,
+        },
 
         #[snafu(display("Failed to write current IP to '{}': {}", path.display(), source))]
         CurrentIpWriteFailed { path: PathBuf, source: io::Error },

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -102,6 +102,7 @@ enum SubCommand {
     Remove(RemoveArgs),
     NodeIp(NodeIpArgs),
     GenerateHostname(GenerateHostnameArgs),
+    SetHostname(SetHostnameArgs),
 }
 
 #[derive(FromArgs, PartialEq, Debug)]
@@ -169,6 +170,15 @@ struct NodeIpArgs {}
 #[argh(subcommand, name = "generate-hostname")]
 /// Generate hostname from DNS reverse lookup or use current IP
 struct GenerateHostnameArgs {}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "set-hostname")]
+/// Write hostname to disk
+struct SetHostnameArgs {
+    #[argh(option)]
+    /// hostname for the system
+    hostname: String,
+}
 
 /// Parse lease data file into a LeaseInfo structure.
 fn parse_lease_info<P>(lease_file: P) -> Result<LeaseInfo>
@@ -303,6 +313,14 @@ where
     Ok(())
 }
 
+/// Persist the hostname to disk
+fn set_hostname(args: SetHostnameArgs) -> Result<()> {
+    fs::write(KERNEL_HOSTNAME, args.hostname).context(error::HostnameWriteFailed {
+        path: KERNEL_HOSTNAME,
+    })?;
+    Ok(())
+}
+
 fn run() -> Result<()> {
     let args: Args = argh::from_env();
     match args.subcommand {
@@ -310,6 +328,7 @@ fn run() -> Result<()> {
         SubCommand::Remove(args) => remove(args)?,
         SubCommand::NodeIp(_) => node_ip()?,
         SubCommand::GenerateHostname(_) => generate_hostname()?,
+        SubCommand::SetHostname(args) => set_hostname(args)?,
     }
     Ok(())
 }

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -226,16 +226,6 @@ fn write_resolv_conf(dns_servers: &[&IpAddr], dns_search: &Option<Vec<String>>) 
     Ok(())
 }
 
-/// Resolve assigned IP address and persist the result as hostname.
-fn update_hostname(ip: &IpNet) -> Result<()> {
-    let host =
-        lookup_addr(&ip.addr()).with_context(|| error::HostnameLookupFailed { ip: ip.addr() })?;
-    fs::write(KERNEL_HOSTNAME, host).context(error::HostnameWriteFailed {
-        path: KERNEL_HOSTNAME,
-    })?;
-    Ok(())
-}
-
 /// Persist the current IP address to file
 fn write_current_ip(ip: &IpAddr) -> Result<()> {
     fs::write(CURRENT_IP, ip.to_string()).context(error::CurrentIpWriteFailed { path: CURRENT_IP })
@@ -255,7 +245,6 @@ fn install(args: InstallArgs) -> Result<()> {
             dns_servers.shuffle(&mut thread_rng());
             write_resolv_conf(&dns_servers, &info.dns_search)?;
             write_current_ip(&info.ip_address.addr())?;
-            update_hostname(&info.ip_address)?;
         }
         _ => eprintln!("Unhandled 'install' command: {:?}", &args),
     }
@@ -348,7 +337,6 @@ mod error {
     use envy;
     use snafu::Snafu;
     use std::io;
-    use std::net::IpAddr;
     use std::path::PathBuf;
 
     #[derive(Debug, Snafu)]
@@ -366,9 +354,6 @@ mod error {
 
         #[snafu(display("Failed to write resolver configuration to '{}': {}", path.display(), source))]
         ResolvConfWriteFailed { path: PathBuf, source: io::Error },
-
-        #[snafu(display("Failed to resolve '{}' to hostname: {}", ip, source))]
-        HostnameLookupFailed { ip: IpAddr, source: io::Error },
 
         #[snafu(display("Failed to write hostname to '{}': {}", path.display(), source))]
         HostnameWriteFailed { path: PathBuf, source: io::Error },

--- a/sources/api/netdog/src/main.rs
+++ b/sources/api/netdog/src/main.rs
@@ -17,6 +17,10 @@ It generates `/etc/resolv.conf`, sets the hostname, and persists the current IP 
 
 #![deny(rust_2018_idioms)]
 
+#[macro_use]
+extern crate serde_plain;
+
+use argh::FromArgs;
 use dns_lookup::lookup_addr;
 use envy;
 use ipnet::IpNet;
@@ -27,12 +31,12 @@ use regex::Regex;
 use serde::Deserialize;
 use snafu::ResultExt;
 use std::collections::BTreeSet;
-use std::fmt::{self, Write};
+use std::fmt::Write;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
-use std::{env, process};
+use std::process;
 
 static RESOLV_CONF: &str = "/etc/resolv.conf";
 static KERNEL_HOSTNAME: &str = "/proc/sys/kernel/hostname";
@@ -42,98 +46,6 @@ static CURRENT_IP: &str = "/var/lib/netdog/current_ip";
 //     FOO='BAR' -> key=FOO, val=BAR
 lazy_static! {
     static ref LEASE_PARAM: Regex = Regex::new(r"^(?P<key>[A-Z]+)='(?P<val>.+)'$").unwrap();
-}
-
-/// Potential errors during netdog execution
-mod error {
-    use envy;
-    use snafu::Snafu;
-    use std::io;
-    use std::net::IpAddr;
-    use std::path::PathBuf;
-
-    #[derive(Debug, Snafu)]
-    #[snafu(visibility = "pub(super)")]
-    #[allow(clippy::enum_variant_names)]
-    pub(super) enum Error {
-        #[snafu(display("Failed to read lease data in '{}': {}", path.display(), source))]
-        LeaseReadFailed { path: PathBuf, source: io::Error },
-
-        #[snafu(display("Failed to parse lease data in '{}': {}", path.display(), source))]
-        LeaseParseFailed { path: PathBuf, source: envy::Error },
-
-        #[snafu(display("Failed to build resolver configuration: {}", source))]
-        ResolvConfBuildFailed { source: std::fmt::Error },
-
-        #[snafu(display("Failed to write resolver configuration to '{}': {}", path.display(), source))]
-        ResolvConfWriteFailed { path: PathBuf, source: io::Error },
-
-        #[snafu(display("Failed to resolve '{}' to hostname: {}", ip, source))]
-        HostnameLookupFailed { ip: IpAddr, source: io::Error },
-
-        #[snafu(display("Failed to write hostname to '{}': {}", path.display(), source))]
-        HostnameWriteFailed { path: PathBuf, source: io::Error },
-
-        #[snafu(display("Failed to write current IP to '{}': {}", path.display(), source))]
-        CurrentIpWriteFailed { path: PathBuf, source: io::Error },
-
-        #[snafu(display("Failed to read current IP data in '{}': {}", path.display(), source))]
-        CurrentIpReadFailed { path: PathBuf, source: io::Error },
-
-        #[snafu(display("Error serializing to JSON: '{}': {}", output, source))]
-        JsonSerialize {
-            output: String,
-            source: serde_json::error::Error,
-        },
-    }
-}
-
-type Result<T> = std::result::Result<T, error::Error>;
-
-#[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
-enum SubCommand {
-    Install,
-    Remove,
-    NodeIp,
-}
-
-impl fmt::Display for SubCommand {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            SubCommand::Install => write!(f, "install"),
-            SubCommand::Remove => write!(f, "remove"),
-            SubCommand::NodeIp => write!(f, "node-ip"),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum InterfaceName {
-    Eth0,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum InterfaceType {
-    Dhcp,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum InterfaceFamily {
-    Ipv4,
-    Ipv6,
-}
-
-/// Stores user-supplied arguments.
-#[derive(Debug)]
-struct Args {
-    interface_name: InterfaceName,
-    interface_type: InterfaceType,
-    interface_family: InterfaceFamily,
-    data_file: PathBuf,
 }
 
 /// Stores fields extracted from a DHCP lease.
@@ -149,100 +61,105 @@ struct LeaseInfo {
     dns_search: Option<Vec<String>>,
 }
 
-/// Informs the user about proper usage of the program and exits.
-fn usage() -> ! {
-    let program_name = env::args().next().unwrap_or_else(|| "program".to_string());
-    eprintln!(
-        r"Usage: {}
-            [ node-ip | install | remove ]
-
-            Required for 'install' and 'remove' subcommands:
-              -i INTERFACE_NAME
-              -t INTERFACE_TYPE
-              -f INTERFACE_FAMILY
-              DATA_FILE",
-        program_name
-    );
-    process::exit(2);
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum InterfaceName {
+    Eth0,
 }
 
-/// Prints a more specific message before exiting through usage().
-fn usage_msg<S: AsRef<str>>(msg: S) -> ! {
-    eprintln!("{}\n", msg.as_ref());
-    usage();
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum InterfaceType {
+    Dhcp,
 }
 
-/// Parses user arguments into a Subcommand and an Args structure.
-fn parse_args(args: env::Args) -> Result<(SubCommand, Option<Args>)> {
-    let mut iter = args.skip(1);
-    let value = iter
-        .next()
-        .unwrap_or_else(|| usage_msg("Did not specify command"));
-    let sub_command = serde_plain::from_str::<SubCommand>(&value)
-        .unwrap_or_else(|_| usage_msg(format!("Unknown command {}", value)));
-
-    // The `node-ip` subcommand doesn't require any arguments
-    if sub_command == SubCommand::NodeIp {
-        return Ok((sub_command, None));
-    };
-
-    let mut interface_name = None;
-    let mut interface_type = None;
-    let mut interface_family = None;
-    let mut data_file = None;
-
-    while let Some(arg) = iter.next() {
-        match arg.as_ref() {
-            "-i" => {
-                let value = iter
-                    .next()
-                    .unwrap_or_else(|| usage_msg("Did not give argument to -i"));
-                interface_name = Some(
-                    serde_plain::from_str::<InterfaceName>(&value)
-                        .unwrap_or_else(|_| usage_msg(format!("Unknown interface name {}", value))),
-                );
-            }
-
-            "-t" => {
-                let value = iter
-                    .next()
-                    .unwrap_or_else(|| usage_msg("Did not give argument to -t"));
-                interface_type = Some(
-                    serde_plain::from_str::<InterfaceType>(&value)
-                        .unwrap_or_else(|_| usage_msg(format!("Unknown interface type {}", value))),
-                );
-            }
-
-            "-f" => {
-                let value = iter
-                    .next()
-                    .unwrap_or_else(|| usage_msg("Did not give argument to -f"));
-                interface_family = Some(
-                    serde_plain::from_str::<InterfaceFamily>(&value).unwrap_or_else(|_| {
-                        usage_msg(format!("Unknown interface family {}", value))
-                    }),
-                );
-            }
-
-            // `wicked` may call this with "info" as the final argument, so if
-            // we already have a data file then we're done.
-            p => match data_file {
-                None => data_file = Some(PathBuf::from(p)),
-                Some(_) => break,
-            },
-        }
-    }
-
-    Ok((
-        sub_command,
-        Some(Args {
-            interface_name: interface_name.unwrap_or_else(|| usage()),
-            interface_type: interface_type.unwrap_or_else(|| usage()),
-            interface_family: interface_family.unwrap_or_else(|| usage()),
-            data_file: data_file.unwrap_or_else(|| usage()),
-        }),
-    ))
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum InterfaceFamily {
+    Ipv4,
+    Ipv6,
 }
+
+// Implement `from_str()` so argh can attempt to deserialize args into their proper types
+forward_from_str_to_serde!(InterfaceName);
+forward_from_str_to_serde!(InterfaceType);
+forward_from_str_to_serde!(InterfaceFamily);
+
+/// Stores user-supplied arguments.
+#[derive(FromArgs, PartialEq, Debug)]
+struct Args {
+    #[argh(subcommand)]
+    subcommand: SubCommand,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand)]
+enum SubCommand {
+    Install(InstallArgs),
+    Remove(RemoveArgs),
+    NodeIp(NodeIpArgs),
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "install")]
+/// Write resolv.conf and current IP to disk
+struct InstallArgs {
+    #[argh(option, short = 'i')]
+    /// name of the network interface
+    interface_name: InterfaceName,
+
+    #[argh(option, short = 't')]
+    /// network interface type
+    interface_type: InterfaceType,
+
+    #[argh(option, short = 'f')]
+    /// network interface family (ipv4/6)
+    interface_family: InterfaceFamily,
+
+    #[argh(positional)]
+    /// lease info data file
+    data_file: PathBuf,
+
+    #[argh(positional)]
+    // wicked might add `info` to the call to this program.  We don't do anything with it but must
+    // be able to parse the option to avoid failing
+    /// ignored
+    info: Option<String>,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "remove")]
+// `wicked` may call `remove` with the below args and failing to parse them can cause an error in
+// `wicked`.
+/// Not implemented
+struct RemoveArgs {
+    #[argh(option, short = 'i')]
+    /// name of the network interface
+    interface_name: InterfaceName,
+
+    #[argh(option, short = 't')]
+    /// network interface type
+    interface_type: InterfaceType,
+
+    #[argh(option, short = 'f')]
+    /// network interface family (ipv4/6)
+    interface_family: InterfaceFamily,
+
+    #[argh(positional)]
+    /// lease info data file
+    data_file: PathBuf,
+
+    #[argh(positional)]
+    // wicked might add `info` to the call to this program.  We don't do anything with it but must
+    // be able to parse the option to avoid failing
+    /// ignored
+    info: Option<String>,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "node-ip")]
+/// Return the current IP address
+struct NodeIpArgs {}
 
 /// Parse lease data file into a LeaseInfo structure.
 fn parse_lease_info<P>(lease_file: P) -> Result<LeaseInfo>
@@ -305,7 +222,7 @@ fn write_current_ip(ip: &IpAddr) -> Result<()> {
     fs::write(CURRENT_IP, ip.to_string()).context(error::CurrentIpWriteFailed { path: CURRENT_IP })
 }
 
-fn install(args: &Args) -> Result<()> {
+fn install(args: InstallArgs) -> Result<()> {
     match (
         &args.interface_name,
         &args.interface_type,
@@ -326,7 +243,7 @@ fn install(args: &Args) -> Result<()> {
     Ok(())
 }
 
-fn remove(args: &Args) -> Result<()> {
+fn remove(args: RemoveArgs) -> Result<()> {
     match (
         &args.interface_name,
         &args.interface_type,
@@ -348,14 +265,11 @@ fn node_ip() -> Result<()> {
 }
 
 fn run() -> Result<()> {
-    match parse_args(env::args())? {
-        (SubCommand::NodeIp, None) => node_ip()?,
-        (SubCommand::NodeIp, Some(_)) => {
-            usage_msg("Subcommand 'node-ip' doesn't support arguments")
-        }
-        (SubCommand::Install, Some(args)) => install(&args)?,
-        (SubCommand::Remove, Some(args)) => remove(&args)?,
-        (subcommand, None) => usage_msg(format!("Subcommand '{}' requires arguments", subcommand)),
+    let args: Args = argh::from_env();
+    match args.subcommand {
+        SubCommand::Install(args) => install(args)?,
+        SubCommand::Remove(args) => remove(args)?,
+        SubCommand::NodeIp(_) => node_ip()?,
     }
     Ok(())
 }
@@ -369,3 +283,49 @@ fn main() {
         process::exit(1);
     }
 }
+
+/// Potential errors during netdog execution
+mod error {
+    use envy;
+    use snafu::Snafu;
+    use std::io;
+    use std::net::IpAddr;
+    use std::path::PathBuf;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility = "pub(super)")]
+    #[allow(clippy::enum_variant_names)]
+    pub(super) enum Error {
+        #[snafu(display("Failed to read lease data in '{}': {}", path.display(), source))]
+        LeaseReadFailed { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Failed to parse lease data in '{}': {}", path.display(), source))]
+        LeaseParseFailed { path: PathBuf, source: envy::Error },
+
+        #[snafu(display("Failed to build resolver configuration: {}", source))]
+        ResolvConfBuildFailed { source: std::fmt::Error },
+
+        #[snafu(display("Failed to write resolver configuration to '{}': {}", path.display(), source))]
+        ResolvConfWriteFailed { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Failed to resolve '{}' to hostname: {}", ip, source))]
+        HostnameLookupFailed { ip: IpAddr, source: io::Error },
+
+        #[snafu(display("Failed to write hostname to '{}': {}", path.display(), source))]
+        HostnameWriteFailed { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Failed to write current IP to '{}': {}", path.display(), source))]
+        CurrentIpWriteFailed { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Failed to read current IP data in '{}': {}", path.display(), source))]
+        CurrentIpReadFailed { path: PathBuf, source: io::Error },
+
+        #[snafu(display("Error serializing to JSON: '{}': {}", output, source))]
+        JsonSerialize {
+            output: String,
+            source: serde_json::error::Error,
+        },
+    }
+}
+
+type Result<T> = std::result::Result<T, error::Error>;

--- a/sources/models/shared-defaults/defaults.toml
+++ b/sources/models/shared-defaults/defaults.toml
@@ -76,6 +76,18 @@ template-path = "/usr/share/templates/proxy-env"
 [metadata.settings.network]
 affected-services = ["containerd", "host-containerd", "host-containers"]
 
+[metadata.settings.network.hostname]
+affected-services = ["hostname"]
+setting-generator = "netdog generate-hostname"
+
+[services.hostname]
+configuration-files = ["hostname"]
+restart-commands = ["/bin/systemctl try-restart set-hostname.service"]
+
+[configuration-files.hostname]
+path = "/etc/network/hostname.env"
+template-path = "/usr/share/templates/hostname"
+
 # NTP
 
 [settings.ntp]

--- a/sources/models/src/lib.rs
+++ b/sources/models/src/lib.rs
@@ -204,6 +204,7 @@ struct HostContainer {
 // Network settings. These settings will affect host service components' network behavior
 #[model]
 struct NetworkSettings {
+    hostname: SingleLineString,
     https_proxy: Url,
     // We allow some flexibility in NO_PROXY values because different services support different formats.
     no_proxy: Vec<SingleLineString>,


### PR DESCRIPTION
**Issue number:**



**Description of changes:**
Previously, hostname was written directly to disk by `netdog` called by `wicked` early in boot.  At this point in the boot sequence, the API server isn't up yet.  Rather than rework the boot sequence and add the ability to netdog to talk to the API, we opted to add a subcommand to `netdog` as a settings generator for the new `settings.network.hostname` setting.  The setting is used in a template file, which is an env file for a new systemd unit that calls `netdog set-hostname`.  This command is what will write the hostname to disk at `/proc/sys/kernel/hostname`.

This means that at boot time, if a user has the `hostname` setting in their user data, we will use it, otherwise we will set the hostname, largely using the same logic as was in the program previously.  (The only change is that if the DNS reverse lookup fails, we use the IP in the format "ip-x-x-x" as the hostname). 

`netdog` was reworked to use `argh` for argument parsing since our custom logic was starting to get unwieldy with the addition of more subcommands with their own arguments.


**Testing done:**



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
